### PR TITLE
Editing for grammar and clarity

### DIFF
--- a/docfx/index.md
+++ b/docfx/index.md
@@ -4,10 +4,10 @@ _layout: landing
 
 # ZeUnit Testing Framework
 
-At the heart of ZeUnit sits a simple principle, functional programing is cleaner.  
-- Tests should be functions.
-- Functions should have all the necessary dependencies.
-- Functions should return a consistent results
+At the heart of ZeUnit sits a simple principle, functional programming is cleaner.  
+- Tests should be functions
+- Functions should have all the necessary dependencies
+- Functions should return consistent results
 
 Taking this "pure" function approach to testing allows some interesting windfall effects that can super charge your testing experience.
 
@@ -30,7 +30,7 @@ public void WhatYouTest()
 
 ## ZeUnit Test
 
-At the heart a test is binary, it passes or fails, so giving a `bool` as a response will be implicity converted to a `Fact` as good stratagy for coders that use descriptive unit tests names.
+At its heart a test is binary, it passes or fails, so giving a `bool` as a response will be implicity converted to a `Fact` as good stratagy for coders that use descriptive unit tests names.
 
 ```csharp
 public Fact WhatYouTestSimpleAssertion()
@@ -42,7 +42,7 @@ public Fact WhatYouTestSimpleAssertion()
 }
 ```
 
-Optionally, the more expressive Shouldly inspired assertion syntax can be used to create instance of `Fact` with additional message feedback and knowledge about the values and the assertion being made.  The example bellow would generate automated message to show the difference between the outcomes, while the example above would flag the test as pass or fail.
+Optionally, the more expressive Shouldly inspired assertion syntax can be used to create an instance of `Fact` with additional message feedback and knowledge about the values and the assertion being made.  The example bellow would generate an automated message to show the difference between the outcomes, while the example above would flag the test as pass or fail.
 
 ```csharp
 public async Task<Fact> WhatYouTestBetterAssertion()

--- a/qwik-docs/src/routes/docs/birdseye-view/index.mdx
+++ b/qwik-docs/src/routes/docs/birdseye-view/index.mdx
@@ -6,7 +6,7 @@ import Warning from '~/components/template/warning'
 
 # Birdseye View of ZeUnit
 
-In the previous section [Getting Started](/), we covered the basics of getting ZeUnit testing set up in your solution, but aside some clever assertion syntax, ZeUnit is yet to offer any real value over the existing frameworks like <a href="https://xunit.net/" target="_blank">XUnit</a>, <a href="https://nunit.org/" target="_blank">NUnit</a> or <a href="https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-with-mstest" target="_blank">MS Test</a>. 
+In the previous section [Getting Started](/), we covered the basics of getting ZeUnit testing set up in your solution.  Aside from some clever assertion syntax, ZeUnit has yet to offer any real value over the existing frameworks like <a href="https://xunit.net/" target="_blank">XUnit</a>, <a href="https://nunit.org/" target="_blank">NUnit</a> or <a href="https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-with-mstest" target="_blank">MS Test</a>. 
 
 <Notes title="Make ZeUnit Yours">
 The language features that are used as examples in this section are just a small subset of the features that ZeUnit has to offer.  More importantly, ZeUnit is designed to be extended and customized to fit the needs of your project.  
@@ -14,12 +14,18 @@ The language features that are used as examples in this section are just a small
 
 ## Simple Suite
 
-The example above in the `SimpleSuite`, is the most basic form that of a test in ZeUnit.  There is no constructor injection or custom method bindings as a result it defaults to `TransientSuite` with a `TransientLifecycleFactory` for the class lifecycle.
+```csharp
 
-The test itself at the low level boils down to a simple assertion: `return value == "expected";`.   With little help from <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/user-defined-conversion-operators" target="_blank">implicit type operators</a> magic the `bool` is converted to a `Fact<bool>` allowing the code to compile and the test to report results. 
+Need Code Here?
+
+```
+
+The example above in the class `SimpleSuite`, is the most basic form of a test in ZeUnit.  There is no constructor injection or custom method bindings.  As a result, it defaults to `TransientSuite` with a `TransientLifecycleFactory` for the class lifecycle.
+
+The test itself, at a low level, boils down to a simple assertion: `return value == "expected";`.   With a little help from <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/user-defined-conversion-operators" target="_blank">implicit type operators</a> magic, the `bool` is converted to a `Fact<bool>` allowing the code to compile and the test to report results. 
 
 <Notes>
-A secondary implicit conversion operator is also created on `Tuple<bool, string>` to support custom messages to be returned along with the tests status.
+A secondary implicit conversion operator is also created on `Tuple<bool, string>` to support custom messages to be returned along with the test's status.
 </Notes>
 
 ```csharp
@@ -33,12 +39,12 @@ public class SimpleSuite : TransientSuite
 ```
 
 <Notes title="Suite Lifecycle">
-The example above explicitly defines the lifecycle by inheriting form the `TransientSuite` class, this the default behavior for classes that don't inherit a Suite class.  More on the lifecycle in the [Test & Suite Lifecycle](/docs/test-suite-lifecycle/) section.
+The example above explicitly defines the lifecycle by inheriting from the `TransientSuite` class, this the default behavior for classes that don't inherit a Suite class.  More on the lifecycle in the [Test & Suite Lifecycle](/docs/test-suite-lifecycle/) section.
 </Notes>
 
 ## Adding Assertions
 
-While the shorthand `bool` and `Tuple<bool, string>` are useful for quick and dirty tests, a simple pass and fails to give enough details for troubleshooting, and having to write out custom messages for every test would become very tedious.  This is where `ZeUnit.Assertions` namespace shines.  The <a href="https://docs.shouldly.org/documentation/getting-started" target="_blank">shoudly</a> inspired collection of helper supercharge the testing process.
+While the shorthand `bool` and `Tuple<bool, string>` are useful for quick and dirty tests, a simple pass and fails to give enough details for troubleshooting, having to write out custom messages for every test would become very tedious.  This is where the `ZeUnit.Assertions` namespace shines.  The <a href="https://docs.shouldly.org/documentation/getting-started" target="_blank">shouldly</a> inspired collection of helpers supercharge the testing process.
 
 ```csharp
 public class AssertionSuite
@@ -54,19 +60,19 @@ public class AssertionSuite
  }
 ``` 
 
-A similar test could be written using the `bool` but would require that is is broken into 3 separate tests or that the test returns the type `IEnumerable<Fact>` allowing for `yield return` syntax for multiple assertions.
+A similar test could be written using the `bool`, but would require that it is broken into 3 separate tests or that the test returns the type `IEnumerable<Fact>` allowing for `yield return` syntax for multiple assertions.
 
-The other added value in using the assertion library over the shorthand `bool` tests is the rich reporting on the objects under tests.  Something that is lost when implicitly converting from `bool` to `Fact`.
+The other added value in using the assertion library, over the shorthand `bool` tests, is rich reporting on the objects under the tests.  This is something that is lost when implicitly converting from `bool` to `Fact`.
 
 ## The Kitchen Sink
 
-The `TheKitchenSinkSuite` class really showcases the power of ZeUnit to create many test with very few lines of code.  Out the gate there are two attributes that define the attributes that are used for class composition to fill the test class dependencies.  
+The `TheKitchenSinkSuite` class really showcases the power of ZeUnit to create many tests with very few lines of code.  Out of the gate, there are two attributes that define the attributes which are used for class composition to fill the test class dependencies.
 
-- The `Singleton` attribute creates a single instance of a value to be shared by all the test that inject the values.  More on this shortly.
+- The `Singleton` attribute creates a single instance of a value to be shared by all the tests that inject the value.  More on this shortly.
 - The `LamarContainer` attribute creates a DI container and registers the `CalculatorRegistry` to the container allowing the `ICalculator` to be injected into the class.
 
 <Notes title="Class Composition">
-These attributes are just a taste of what can be done before the test is executed by creating domain specific attributes unique to your project by overriding `ZeClassComposer` and ZeComposerAttribute` classes.  See more [Class Composers](/docs/core-class-composers/) or [Custom Class Composers](/docs/building-class-composers/).
+These attributes are just a taste of what can be done before the test is executed by creating domain specific attributes unique to your project by overriding the `ZeClassComposer` and `ZeComposerAttribute` classes.  See more [Class Composers](/docs/core-class-composers/) or [Custom Class Composers](/docs/building-class-composers/).
 </Notes>
 
 ```csharp
@@ -95,15 +101,15 @@ public class TheKitchenSinkSuite
     }    
 }
 ```
-The `InlineData` is a familiar tool of existing unit testing frameworks, but just like the `ZeClassComposer` customizations ZeUnit focus on making custom method bindings easy to create.  More on this in the [Method Bindings](/docs/core-method-binders/) section.
+The `InlineData` is a familiar tool of existing unit testing frameworks, but just like the `ZeClassComposer` customizations, ZeUnit focuses on making custom method bindings easy to create.  More on this in the [Method Bindings](/docs/core-method-binders/) section.
 
-Back to the single instance of `SingletonCounter` which might seem out of place in a test suite that is transient.  However building a testing framework on top of reactive IObservable classes, being able to build out dependencies chaines that for behavior becomes pretty trivial.  For the purists this is a unit test code smell, but as ZeUnit scales to larger integration and end-to-end tests, the ability to share state between tests that can follow each other becomes a powerful tool.
+Back to the single instance of `SingletonCounter` which might seem out of place in a test suite that is transient.  However, when building a testing framework on top of reactive IObservable classes, being able to build out dependency chains for that behavior becomes pretty trivial.  For the purists this is a unit test code smell, but as ZeUnit scales to larger integration and end-to-end tests, the ability to share state between tests that can follow each other becomes a powerful tool.
 
 <Warning title="Prototype">
 The features around `DependsOn` are not currently implemented in the current version of ZeUnit.  They are planned for a future release.
 </Warning>
 
-- `[DependsOn("AddOneMoreFirst")]` is doing some interesting work allowing us to define that some tests in the suite have to run before others by creating a dependency.
+- `[DependsOn("AddOneMoreFirst")]` is doing some interesting work, allowing us to define that some tests in the suite have to run before others by creating a dependency
 - `[DependsOn(typeof(TheKitchenSinkSuite))]` is a way to define that `NextKitchenSinkSuite` depends on `TheKitchenSinkSuite` to be run first 
 
 
@@ -136,11 +142,11 @@ public class NextKitchenSinkSuite
 
 ### Understanding The Lifecycle 
 
-The outcome here is that `TheKitchenSinkSuite` is run first allowing each of the `InlineData` method binding to execute the `AdditionHarness` method.  This keeps incrementing the `SingletonCounter` and which is always the same despite `TheKitchenSinkSuite` being transient for each instance of the method binding.
+The outcome here is that `TheKitchenSinkSuite` is run first, allowing each of the `InlineData` method bindings to execute the `AdditionHarness` method.  This keeps incrementing the `SingletonCounter`, which is always the same despite `TheKitchenSinkSuite` being transient for each instance of the method binding.
 
-Once all of tests in `TheKitchenSinkSuite` the dependency defined on `NextKitchenSinkSuite` with the `IZeDependency<TheKitchenSinkSuite>` interface is satisfied and ZeUnit will pick up the Facts.  The lifecycle of this class however is modified by inheritance from the `OrderedSuite<NextKitchenSinkOrder>` which defers figuring out method fact dependencies as a `SuiteOrder` class.
+Once all of the tests in `TheKitchenSinkSuite`, the dependency defined on `NextKitchenSinkSuite` with the `IZeDependency<TheKitchenSinkSuite>` interface, are satisfied, ZeUnit will pick up the Facts.  The lifecycle of this class, however, is modified by inheritance from the `OrderedSuite<NextKitchenSinkOrder>`, which defers figuring out method fact dependencies as a `SuiteOrder` class.
 
-The `SuiteOrder` override method behind the scene wraps around some `IObservable` magic allowing tests to shake out dependencies as they complete.  The sudo code definition in the none functional example above would require that the Fact `AddOneMoreFirst` is run before `CheckTotalValue` is run.  This makes the Counter value 5 and the finally test pass.
+The `SuiteOrder` override method behind the scenes wraps around some `IObservable` magic allowing tests to shake out dependencies as they complete.  The sudo code definition in the none functional example above would require that the Fact `AddOneMoreFirst` is run before `CheckTotalValue` is run.  This makes the Counter value 5 and the final test pass.
 
 ---
 

--- a/qwik-docs/src/routes/docs/core-class-composers/index.mdx
+++ b/qwik-docs/src/routes/docs/core-class-composers/index.mdx
@@ -6,13 +6,13 @@ import Warning from '~/components/template/warning'
     This page is under construction and may contain incomplete or incorrect information.
 </Warning>
 
-For a test to execute, a class needs to exist.  But before the class the exist, the dependencies also need to exist, and `ZeClassComposer` is the how handles getting the dependencies.  When a `Fact` is discovered, ZeUnit looks at the class type and identifies the lifecycle and based on that lifecycle creates a class factory that the test runner can call to get a test class.  When that test class has dependencies, `ZeClassComposer` classes become the sources for those dependencies.  
+For a test to execute, a class needs to exist.  Before the class exists, the dependencies also need to exist, and `ZeClassComposer` is how it handles getting the dependencies.  When a `Fact` is discovered, ZeUnit looks at the class type and identifies the lifecycle. Based on that lifecycle, it creates a class factory that the test runner can call to get a test class.  When that test class has dependencies, `ZeClassComposer` classes become the sources for those dependencies.  
 
 
 The default lifecycles are inherited from:
 
-- `TransientSuite` - The default class lifecycle.  Automatically be applied to test classes that have inherit from a `Suite` class.
-- `ReEntrySuite` -  Singleton lifecycle for the test class and as a result may require some tests to execute before others allowing the suite to be its own state machine.
+- `TransientSuite` - The default class lifecycle that is automatically applied to test classes which inherit from a `Suite` class
+- `ReEntrySuite` -  Singleton lifecycle for the test class and as a result may require some tests to execute before others allowing the suite to be its own state machine
 
 
 ***

--- a/qwik-docs/src/routes/docs/core-method-binders/index.md
+++ b/qwik-docs/src/routes/docs/core-method-binders/index.md
@@ -1,20 +1,20 @@
 # Method Binders 
 
-Method composition is the mechanism for injecting test data into your tests.  In the previous section [Testing A Calculator](/docs/Testing-A-Calculator.html), we saw `InlineData` attributes being used to push data into a single test method.  While this is useful in many unit tests scenarios, scaling this to integration testing becomes tedious, especially with the dotnet limitations on primitive types as arguments for Attributes.  To bridge the gap into integration testing ZeUnit comes equipped with tools to help you work with test data.
+Method composition is the mechanism for injecting test data into your tests.  In the previous section [Testing A Calculator](/docs/Testing-A-Calculator.html), we saw `InlineData` attributes being used to push data into a single test method.  While this is useful in many unit test scenarios, scaling this to integration testing becomes tedious, especially with the DotNet limitations on primitive types as arguments for Attributes.  To bridge the gap into integration testing, ZeUnit comes equipped with tools to help you work with test data.
 
-This is a common trend of integration frameworks, the idea of a detached data state that doesn't require the test code to be modified for additional test cases to run.
+This is a common trend of integration frameworks, it is the idea of a detached data state that doesn't require the test code to be modified for additional test cases to run.
 
-- Fitness: Wiki files and commonly xml/json data files the wikis point to.
-- SpecFlow: Cucumber and again points to a file.
-- ZeUnit takes a more holistic approach and allows method composer to consume files directly for test execution.  
+- Fitness: Wiki files and commonly xml/json data files the wikis point to
+- SpecFlow: Cucumber and again points to a file
+- ZeUnit takes a more holistic approach and allows method composer to consume files directly for test execution
 
 ## Binding To Files
 
-In the example below, we can see the same test.txt file being loading with each test method.  The key difference is the argument type allowing to pull in the file as low level or high level as is necessary:
+In the example below, we can see the same test.txt file being loading with each test method.  The key difference is the argument type allowing us to pull in the file as low level or high level as is necessary:
 
 - Stream
-- byte[]
 - string
+- byte[]
 
 ```csharp
 public class FileInjectionTests
@@ -45,7 +45,7 @@ public class FileInjectionTests
 
 ## Developer Integration Testing
 
-While loading raw files is some time useful, chances are the test data being loaded represent some serializable type, so additionally json and xml files can be targeted to any POCO class and the binding will attempt to deserialize the type.  Serializable types are especially useful when dealing with common starting scenarios that can be reused across a wide range of tests.
+While loading raw files is sometimes useful, chances are the test data being loaded represents some serializable type. Additionally, json and xml files can be targeted to any POCO class and the binding will attempt to deserialize the type.  Serializable types are especially useful when dealing with common starting scenarios that can be reused across a wide range of tests.
 
 ```csharp
 public class DeserializeTests
@@ -67,7 +67,7 @@ public class DeserializeTests
 
 ## Taking it Full Scale
 
-The examples so far still fail to meet the needs of integrations testing at scale because the files being used are always hard coded with in the assembly.  This means, only developers could make changes there and meaning that SMEs still need developer engagement for creating additional testing.  As mentioned earlier, method composition can result in 1 or more tests being run, so the natural progression from a `LoadFile` would the `LoadFiles` which reads over a directory and creates a test for each file found.
+The examples so far still fail to meet the needs of integrations testing at scale because the files being used are always hard coded within the assembly.  This means, only developers can make changes there and SMEs still need developer engagement for creating additional testing.  As mentioned earlier, method composition can result in 1 or more tests being run. The natural progression from a `LoadFile` would be the `LoadFiles`, which reads over a directory and creates a test for each file found.
 
 ```csharp
     public class DirectoryInjectionTests
@@ -87,12 +87,12 @@ The examples so far still fail to meet the needs of integrations testing at scal
     }
 ```
 
-To avoid indiscriminately grabbing all the files in a directory, the `LoadFiles` method composer is able to process additional information from the `ExtensionFilter` attribute on method parameters.  Adding this attribute to the code will only pick up on file with names ending in the defined extension.
+To avoid indiscriminately grabbing all the files in a directory, the `LoadFiles` method composer is able to process additional information from the `ExtensionFilter` attribute on the method parameters.  Adding this attribute to the code will only load files with names ending in the defined extension.
 
-ZeUnit steps this up one more notch with the introduction of the `LoadFileGroups` method composer that is able to group files together by name and populate multiple method parameters based on matching filters.  Grouping data sets into multiple files like the test data and the expected result files like the example below empowers the recruitment of business SMEs to generate better tests data and having stronger confidence in the system.
+ZeUnit steps this up one more notch with the introduction of the `LoadFileGroups` method composer. This composer is able to group files together by name and populate multiple method parameters based on matching filters.  Grouping data sets into multiple files like the test data and the expected result files like the example below empowers the recruitment of business SMEs to generate better test data and having stronger confidence in the system.
 
 ```csharp
-   public class DirectoryFileSetsInejctionTests 
+   public class DirectoryFileSetsInjectionTests 
     { 
         [LoadFileGroups("FileTests/test/")]
         public Fact LoadedFromDirectoryWithMultipleExtension(
@@ -104,7 +104,7 @@ ZeUnit steps this up one more notch with the introduction of the `LoadFileGroups
     }
 ```
 
-The method composition system is open to be extension by writing additional method composers.  More information about building custom method composers can be found in here: [Custom Method Composition](/docs/Custom-Method-Composition.html)
+The method composition system is open to extension by writing additional method composers.  More information about building custom method composers can be found in here: [Custom Method Composition](/docs/Custom-Method-Composition.html)
 
 ***
 Next Section [Class Composition](/docs/core-class-composers)

--- a/qwik-docs/src/routes/docs/example-calculator-tests/index.mdx
+++ b/qwik-docs/src/routes/docs/example-calculator-tests/index.mdx
@@ -2,16 +2,16 @@ The `SampleZeUnitClass` test in the [Getting Started](/) section, was the canary
 
 ### Lesson Plan:
 
-- Look over some basic unit tests against the addition operation.
-- Showcase the benefits of using method activation to reduce the amount of duplicate code.
-- Scale our test to integration by leveraging custom class activation.
+- Look over some basic unit tests against the addition operation
+- Showcase the benefits of using method activation to reduce the amount of duplicate code
+- Scale our test to integration by leveraging custom class activation
 
 
 The calculator code being tested here can be found here: [/ZeUnit.Demo/DemoCalculator](https://github.com/bitcobblers/ZeUnit/tree/master/ZeUnit.Demo/DemoCalculator). 
 
 ## Different, but Kind of the Same
 
-We are hardy SOLID programmers, and as a result we should focus on a single responsibility.  Lets take a closer look at what it means to add different number of arguments on the calculator.  The tests below are written in a format that should feel familiar to developers already doing testing in dotnet.  What is different here from the existing frameworks is that tests return a results, which is analogous to a call against the Assert class in traditional unit testing frameworks. 
+We are hardy SOLID programmers, and as a result we should focus on a single responsibility.  Lets take a closer look at what it means to add a different number of arguments on the calculator.  The tests below are written in a format that should feel familiar to developers already doing testing in DotNet.  What is different here, from the existing frameworks, is that tests return a results, which is analogous to a call against the Assert class in traditional unit testing frameworks. 
 
 ```csharp
 public Fact PassingNullValueWillResultInZero()
@@ -49,7 +49,7 @@ public Fact PassingManyValuesResultWithTheSum()
 
 ## Getting Some Reusability
 
-The code above is verbose, and "I pity the fool" who has to deal with all the code changes when the `Apply` method signature changes or a large number of additional similar tests need to be created. And really the only difference between the individual tests above is the data inputs and expectations.  So let's see what we get when we sprinkle some ZeUnit magic on the code above.
+The code above is verbose, and "I pity the fool" who has to deal with all the code changes when the `Apply` method signature changes or a large number of additional similar tests need to be created. And really, the only difference between the individual tests above is the data inputs and expectations.  So let's see what we get when we sprinkle some ZeUnit magic on the code above.
 
 ```csharp
 public class TestingAdditionInlineData
@@ -68,13 +68,13 @@ public class TestingAdditionInlineData
 }
 ```
 
-The instances of the `InlineData` attributes each represent a single entry/test in this test class.  We have a repeating code harness and we run different scenarios though it, saving us much code and making adding additional similar data tests a beaze.
+The instances of the `InlineData` attributes each represent a single entry/test in this test class.  We have a repeating code harness and we run different scenarios though it, saving us much code and making adding additional similar data tests a breeze.
 
-`InlineData` method attribute is inspired by the `Theory` attribute from XUnit. However, in the ZeUnit universe, test method attributes of type `ZeComposerAttribute` represent an entire class of method composers that super charge the developers ability to consume test data.  ZeUnit comes stocked with some common method activators like the `InlineData` attribute.  See [Existing Method Composition](/docs/Existing-Method-Composition.html) & [Custom Method Composition](/docs/Custom-Method-Composition.html).
+`InlineData` method attribute is inspired by the `Theory` attribute from XUnit. However, in the ZeUnit universe, test method attributes of type `ZeComposerAttribute` represent an entire class of method composers that supercharge the developer's ability to consume test data.  ZeUnit comes stocked with some common method activators like the `InlineData` attribute.  See [Existing Method Composition](/docs/Existing-Method-Composition.html) & [Custom Method Composition](/docs/Custom-Method-Composition.html).
 
 ## Putting it all Together
 
-Assuming all the `ICalculatorOperation` are well tested, can we be sure that everything works?  Well not really, because while we have tested all the operations, we haven't really created any tests against the calculator itself.   Sure, unit testing the mechanics of the apply function on the calculator class is a must, but those shouldn't depend on any specific instances of `ICalculatorOperation`.  There is also the bootstrapping of the calculator at load time.  We have the ability to register any number of `ICalculatorOperation` with an instance of the calculator.  Testing defaults or custom modules for example would also add value and bring up the developer confidence level.
+Assuming all the `ICalculatorOperation` are well tested, can we be sure that everything works?  Well not really, because while we have tested all the operations, we haven't really created any tests against the calculator itself.   Sure, unit testing the mechanics of the apply function on the calculator class is a must, but those shouldn't depend on any specific instances of `ICalculatorOperation`.  There is also the bootstrapping of the calculator at load time.  We have the ability to register any number of `ICalculatorOperation` with an instance of the calculator.  Testing defaults or custom modules, for example, would also add value and bring up the developer's confidence level.
 
 Lets take a look at what that looks like with ZeUnit.
 

--- a/qwik-docs/src/routes/docs/rich-assertions/index.mdx
+++ b/qwik-docs/src/routes/docs/rich-assertions/index.mdx
@@ -2,12 +2,12 @@ import Warning from '~/components/template/warning'
 
 # Rich Assertions with Fluent Syntax
 
-A strong validation of a good idea is the way that many may try to replicate it.  One can only speculate but both of these liberies seem to dislike `Assert` as they seem to do away with the need for it.
+A strong validation of a good idea is the way that many may try to replicate it.  One can only speculate, but both of these libraries seem to dislike `Assert` as they seem to do away with the need for it.
 
 - [shouldly](https://docs.shouldly.org/)
 - [Fluent Assertions](https://fluentassertions.com/introduction)
 
-It should come as no suprise that the syntax style these libraries use can find such synergy with the functional style of testing that is offered by ZeUnit.
+It should come as no surprise that the syntax style these libraries use can find such synergy with the functional style of testing that is offered by ZeUnit.
 
 ## What is `Fact<TType>`?
 

--- a/qwik-docs/src/routes/docs/test-execution/index.mdx
+++ b/qwik-docs/src/routes/docs/test-execution/index.mdx
@@ -9,10 +9,10 @@ import Warning from '~/components/template/warning'
 
 Developers familiar with existing testing frameworks like XUnit and NUnit will notices some key differences:
 
- - The familiar `Assert` has been replaced by `new Fact()` or a collection of `Shouldly` style assertion helpers.  
- - Test methods return `Fact` in the case of single synchronous test result and `Task<Fact>` when the single result is asynchronous. 
+ - The familiar `Assert` has been replaced by `new Fact()` or a collection of `Shouldly` style assertion helpers
+ - Test methods return `Fact` in the case of single synchronous test result and `Task<Fact>` when the single result is asynchronous
 
-ZeUnit borrows a lot from functional programing, and requires that functions return results. In our case the `Fact` object which can have 0 or more assertions like `Equal` or `Type` in the code example above.   Labeling the test function with resulting type as defined in the table below allows you to define the execution timeline of your test(s) and how the `Fact` object(s) is/are being returned.
+ZeUnit borrows a lot from functional programming, and requires that functions return results. In our case the `Fact` object which can have 0 or more assertions like `Equal` or `Type` in the code example above.   Labeling the test function with a resulting type as defined in the table below allows you to define the execution timeline of your test(s) and how the `Fact` object(s) is/are being returned.
 
 |  Test Results   | **One**          |  **Many**               |
 | --------------- | ---------------- | ----------------------- |

--- a/qwik-docs/src/routes/docs/test-suite-lifecycle/index.mdx
+++ b/qwik-docs/src/routes/docs/test-suite-lifecycle/index.mdx
@@ -10,10 +10,10 @@ import Warning from '~/components/template/warning'
 
 Developers familiar with existing testing frameworks like XUnit and NUnit will notice some key differences:
 
- - The familiar `Assert` has been replaced by `new Fact()` or a collection of `Shouldly` style assertion helpers.  
- - Test methods return `Fact` in the case of single synchronous test result and `Task<Fact>` when the single result is asynchronous. 
+ - The familiar `Assert` has been replaced by `new Fact()` or a collection of `Shouldly` style assertion helpers
+ - Test methods return `Fact` in the case of single synchronous test result and `Task<Fact>` when the single result is asynchronous
 
-ZeUnit borrows a lot from functional programming and requires that functions return results. In our case the `Fact` object which can have 0 or more assertions like `Equal` or `Type` in the code example above.   Labeling the test function with resulting type as defined in the table bellow allows you to expressly define the execution timeline of your test(s) and how the `Fact` object(s) is/are being returned.
+ZeUnit borrows a lot from functional programming, and requires that functions return results. In our case the `Fact` object which can have 0 or more assertions like `Equal` or `Type` in the code example above.   Labeling the test function with a resulting type as defined in the table below allows you to define the execution timeline of your test(s) and how the `Fact` object(s) is/are being returned.
 
 |  Test Results   | **One**          |  **Many**               |
 | --------------- | ---------------- | ----------------------- |

--- a/qwik-docs/src/routes/index.mdx
+++ b/qwik-docs/src/routes/index.mdx
@@ -16,7 +16,7 @@ Install-Package ZeUnit.TestAdapter
 Install-Package Microsoft.NET.Test.Sdk
 ```
 
-Paste the `SampleSuite` to replace implementation in `Class1.cs` file that is automatically created for you by Visual Studio.
+Use the `SampleSuite` code below to replace the initial implementation of `Class1.cs`, the file that is automatically created for you by Visual Studio.
 
 ```csharp
 public class SampleSuite
@@ -37,29 +37,28 @@ public class SampleSuite
 }
 ```
 
-Open up the Test Explorer window in Visual studio, and kick off the tests.  It will display a passing and failing result for the two tests we created above.
+Open the Test Explorer window in Visual Studio, and kick off the tests.  It will display a passing and failing result for the two tests we created above.
 
 ## A Deeper Dive
 
-At the heart of ZeUnit sits a design simple principle; a test is a function and functions return result(s). For ZeUnit that result is a `Fact` which reports back to the test runner.  The benefits?  A testing platform that is simple use & easily extensible with the tools the system is built on: It is just chaining function execution.   
+At the heart of ZeUnit sits a simple design principle; a test is a function and functions return result(s). For ZeUnit, that result is a `Fact` which reports back to the test runner.  The benefits?  A testing platform that is simple to use and easily extensible with the tools the system is built on: It is just chaining function executions.   
 
 ### Custom method bindings
 
-Take the familiar example of `InlineData`, which defines some type of test parameters and give it the super power to easily [write your own](/docs/building-method-binders/).  With the goal to abstract the often repeating code which loads tests data and likely serializes it, the primary candidates for a b [built-in binder](/docs/core-method-binders/) collection are focused on file access.
+Take the familiar example of `InlineData`, which defines some types of test parameters and gives you the superpower to easily [write your own](/docs/building-method-binders/).  With the goal to abstract the often repeating code which loads tests data and likely serializes it, the primary candidates for a [built-in binder](/docs/core-method-binders/) collection are focused on file access.
 
 <Notes title="Discovery Life-Cycle">
-The `IZeMethodBinder` interface implementation described in [/docs/building-method-binders](/docs/building-method-binders) can generates zero or more test, additional data files to be treated is valid new tests.
+The `IZeMethodBinder` interface implementation described in [/docs/building-method-binders](/docs/building-method-binders) can generates zero or more tests / additional data files to be treated as valid new tests.
 </Notes>
 
 ### Class composition
 
-Your test have dependencies and ZeUnit gives the pathway to [inject](/docs/core-class-composers/) them directly into the test class. 
+Your tests have dependencies and ZeUnit gives the pathway to [inject](/docs/core-class-composers/) them directly into the test class. 
 
 
 ### Life-cycle & Dependency Chaining
 
 **Control over the life-cycle**: One class or many? One dependency or many? When a framework spans from unit to integration to end-to-end tests, the ability to control the [life-cycle](/docs/test-suite-lifecycle/) of the test class becomes a powerful tool.
-
 
 
 ### Standalone Reporting


### PR DESCRIPTION
I think there's one place on the birdseye page where you meant to have a code example, or there was one but it got moved to a different page. I added a code section but left it as a placeholder for you to decide what you wanted to do there. 